### PR TITLE
Remove extra double quote from unix domain socket in unicorn config file...

### DIFF
--- a/recipes/unicorn.rb
+++ b/recipes/unicorn.rb
@@ -8,8 +8,8 @@ end
 node.default[:unicorn][:preload_app] = true
 node.default[:unicorn][:worker_processes] = [node[:cpu][:total].to_i * 4, 8].min
 node.default[:unicorn][:preload_app] = false
-node.default[:unicorn][:before_fork] = 'sleep 1' 
-node.default[:unicorn][:port] = '"unix:/' + File.join(node[:geminabox][:base_directory], 'unicorn.socket') + '"'
+node.default[:unicorn][:before_fork] = 'sleep 1'
+node.default[:unicorn][:port] = 'unix:/' + File.join(node[:geminabox][:base_directory], 'unicorn.socket')
 node.set[:unicorn][:options] = { :tcp_nodelay => true, :backlog => 100 }
 
 unicorn_config File.join(node[:geminabox][:config_directory], 'geminabox.unicorn.app') do


### PR DESCRIPTION
....

With the extra double quote I saw this:

$ red_unicorn -x /usr/bin/unicorn -c /etc/geminabox/geminabox.unicorn.app -p /mnt/ebs1/geminabox/unicorn.pid restart
WARN: RedUnicorn::FileNotFound: PID file not found. Provided path: /mnt/ebs1/geminabox/unicorn.pid
WARN: unicorn not currently running. Starting.
WARN: RedUnicorn::FileNotFound: PID file not found. Provided path: /mnt/ebs1/geminabox/unicorn.pid
/usr/lib64/ruby/gems/1.9.1/gems/unicorn-4.3.1/lib/unicorn/configurator.rb:74:in `instance_eval': /etc/geminabox/geminabox.unicorn.app:7: syntax error, unexpected tIDENTIFIER, expecting $end (SyntaxError)
listen ""unix://mnt/ebs1/geminabox/unicorn...
             ^
    from /usr/lib64/ruby/gems/1.9.1/gems/unicorn-4.3.1/lib/unicorn/configurator.rb:74:in`reload'
    from /usr/lib64/ruby/gems/1.9.1/gems/unicorn-4.3.1/lib/unicorn/configurator.rb:67:in `initialize'
    from /usr/lib64/ruby/gems/1.9.1/gems/unicorn-4.3.1/lib/unicorn/http_server.rb:104:in`new'
    from /usr/lib64/ruby/gems/1.9.1/gems/unicorn-4.3.1/lib/unicorn/http_server.rb:104:in `initialize'
    from /usr/lib64/ruby/gems/1.9.1/gems/unicorn-4.3.1/bin/unicorn:121:in`new'
    from /usr/lib64/ruby/gems/1.9.1/gems/unicorn-4.3.1/bin/unicorn:121:in `<top (required)>'
    from /usr/bin/unicorn:23:in`load'
    from /usr/bin/unicorn:23:in `<main>'
master failed to start, check stderr log for details
Unicorn action restart completed successfully.

After removing it:

$ red_unicorn -x /usr/bin/unicorn -c /etc/geminabox/geminabox.unicorn.app -p /mnt/ebs1/geminabox/unicorn.pid restart
WARN: RedUnicorn::FileNotFound: PID file not found. Provided path: /mnt/ebs1/geminabox/unicorn.pid
WARN: unicorn not currently running. Starting.
WARN: RedUnicorn::FileNotFound: PID file not found. Provided path: /mnt/ebs1/geminabox/unicorn.pid
Unicorn action restart completed successfully.

Not sure why the first one exited 0, but since chef likes to eat stderr/stdout it sure made debugging a pleasure.
