### PR TITLE
Disambiguate ssl enabled flag.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,7 @@ default[:geminabox][:auth_required] = false
 # sys configs
 default[:geminabox][:www_user] = 'www-data'
 # ssl configs
-default[:geminabox][:ssl] = false 
+default[:geminabox][:ssl][:enabled] = false
 # unicorn configs
 default[:geminabox][:unicorn] = Mash.new
 default[:geminabox][:unicorn][:install] = false

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -6,7 +6,7 @@ include_recipe 'nginx'
   end
 end
 
-if(node[:geminabox][:ssl].respond_to?(:[]))
+if(node[:geminabox][:ssl][:enabled])
   geminabox_key = node[:geminabox][:ssl][:key]
   geminabox_cert = node[:geminabox][:ssl][:cert]
 end


### PR DESCRIPTION
This one is arguable.  I'll explain what I'm trying to accomplish.   You decide whether you think this is the right approach ;)

This is what I'm trying to do - use the chef .json role stuff:

{
    "name":"gemsrepo",
    "chef_type":"role",
    "json_class":"Chef::Role",
    "default_attributes":{
    },
    "description":"geminabox on top of nginx + unicorn (what github uses)",
    "run_list":[
        "recipe[ruby]", "recipe[geminabox]"
    ],
    "override_attributes":{
        "geminabox": {
            "ssl": {
                "key": "/foo",
                "cert": "/bar"
            }
        }
    }
}

Before the change I got this:

[2012-09-28T00:04:52-04:00] INFO: **\* Chef 10.14.2 ***
[2012-09-28T00:04:54-04:00] INFO: Setting the run_list to ["role[gemsrepo]", "role[nagios_client]"] from JSON
[2012-09-28T00:04:54-04:00] INFO: Run List is [role[gemsrepo], role[nagios_client]]
[2012-09-28T00:04:54-04:00] INFO: Run List expands to [ruby, geminabox, nagios::client]
[2012-09-28T00:04:54-04:00] INFO: Starting Chef Run for ip-10-252-77-246.us-west-2.compute.internal
[2012-09-28T00:04:54-04:00] INFO: Running start handlers
[2012-09-28T00:04:54-04:00] INFO: Start handlers complete.
[2012-09-28T00:04:54-04:00] INFO: ohai plugins will be at: /etc/chef/ohai_plugins
[2012-09-28T00:04:54-04:00] INFO: Processing remote_directory[/etc/chef/ohai_plugins] action create (ohai::default line 23)
[2012-09-28T00:04:54-04:00] INFO: Processing cookbook_file[/etc/chef/ohai_plugins/README] action create (dynamically defined)
[2012-09-28T00:04:54-04:00] INFO: Processing ohai[custom_plugins] action reload (ohai::default line 34)
[2012-09-28T00:04:56-04:00] INFO: ohai[custom_plugins] reloaded
# 
# Recipe Compile Error in /tmp/exec/cookbooks/geminabox/recipes/default.rb
## NoMethodError

undefined method `has_key?' for false:FalseClass
## Cookbook Trace:

  /tmp/exec/cookbooks/geminabox/recipes/nginx.rb:10:in `from_file'
  /tmp/exec/cookbooks/geminabox/recipes/default.rb:18:in`from_file'
## Relevant File Content:

/tmp/exec/cookbooks/geminabox/recipes/nginx.rb:

  1:  include_recipe 'nginx'
  2:
  3:  %w(000-default default).each do |site|
  4:    nginx_site site do
  5:      enable false
  6:    end
  7:  end
  8:
  9:  if(node[:geminabox][:ssl].respond_to?(:[]))

[2012-09-28T00:04:56-04:00] ERROR: Running exception handlers
[2012-09-28T00:04:56-04:00] ERROR: Exception handlers complete
[2012-09-28T00:04:56-04:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2012-09-28T00:04:56-04:00] FATAL: NoMethodError: undefined method `has_key?' for false:FalseClass
Generated at 2012-09-28 00:04:56 -0400
NoMethodError: undefined method`has_key?' for false:FalseClass
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/node/attribute.rb:388:in `value_or_descend'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/node/attribute.rb:109:in`[]'
/tmp/exec/cookbooks/geminabox/recipes/nginx.rb:10:in `from_file'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/from_file.rb:30:in`instance_eval'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/from_file.rb:30:in `from_file'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/cookbook_version.rb:558:in`load_recipe'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/language_include_recipe.rb:46:in `load_recipe'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/language_include_recipe.rb:33:in`block in include_recipe'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/language_include_recipe.rb:27:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/language_include_recipe.rb:27:in`include_recipe'
/tmp/exec/cookbooks/geminabox/recipes/default.rb:18:in `from_file'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/from_file.rb:30:in`instance_eval'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/from_file.rb:30:in `from_file'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/cookbook_version.rb:558:in`load_recipe'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/language_include_recipe.rb:46:in `load_recipe'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/language_include_recipe.rb:33:in`block in include_recipe'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/language_include_recipe.rb:27:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/mixin/language_include_recipe.rb:27:in`include_recipe'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/run_context.rb:79:in `block in load'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/run_context.rb:75:in`each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/run_context.rb:75:in `load'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/client.rb:198:in`setup_run_context'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/client.rb:418:in `do_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/client.rb:176:in`run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/application/solo.rb:230:in `block in run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/application/solo.rb:218:in`loop'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/application/solo.rb:218:in `run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/lib/chef/application.rb:70:in`run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.2/bin/chef-solo:25:in `<top (required)>'
/usr/bin/chef-solo:23:in`load'
/usr/bin/chef-solo:23:in `<main>'
Deploy to  [FAIL]

With the change, no more errors, but my role.json changes sligtly to this:

{
    "name":"gemsrepo",
    "chef_type":"role",
    "json_class":"Chef::Role",
    "default_attributes":{
    },
    "description":"geminabox on top of nginx + unicorn (what github uses)",
    "run_list":[
        "recipe[ruby]", "recipe[geminabox]"
    ],
    "override_attributes":{
        "geminabox": {
            "ssl": {
                "enabled": true,
                "key": "foo",
                "cert": "bar"
            }
        }
    }
}
