### PR TITLE
add name attribute to avoid chef error

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,7 @@ license          "Apache 2.0"
 description      "Installs and configures Geminabox"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.1.2"
+name             "geminabox"
 
 supports 'ubuntu'
 depends 'unicorn'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,14 +24,14 @@ gem_package('geminabox') do
   version node[:geminabox][:version] || '~> 0.6.0'
 end
 
-# Load up the monitoring
-if(node[:geminabox][:bluepill] || :this_is_all_we_support)
-  include_recipe 'geminabox::bluepill'
-end
-
 # Configure up server instance
 if(node[:geminabox][:unicorn] || :this_is_all_we_support)
   include_recipe 'geminabox::unicorn'
+end
+
+# Load up the monitoring
+if(node[:geminabox][:bluepill] || :this_is_all_we_support)
+  include_recipe 'geminabox::bluepill'
 end
 
 template File.join(node[:geminabox][:base_directory], 'config.ru') do


### PR DESCRIPTION
Tried using your cookbook with Berkshelf today and got this error:

```
Ridley::Errors::MissingNameAttribute The metadata at '/tmp/d20140424-4299-1xwugi0' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.

```
