### PR TITLE
Support for authenticate only POST method.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,7 @@ default[:geminabox][:rubygems_proxy] = false
 # auth configs
 default[:geminabox][:auth_required] = false
 default[:geminabox][:limit_post] = false
+default[:geminabox][:network_list] = nil
 # sys configs
 if ['rhel', 'fedora'].include? node[:platform_family]
   default[:geminabox][:www_user] = 'nginx'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,7 @@ default[:geminabox][:build_legacy] = false
 default[:geminabox][:rubygems_proxy] = false
 # auth configs
 default[:geminabox][:auth_required] = false
+default[:geminabox][:limit_post] = false
 # sys configs
 if ['rhel', 'fedora'].include? node[:platform_family]
   default[:geminabox][:www_user] = 'nginx'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "chrisroberts.code@gmail.com"
 license          "Apache 2.0"
 description      "Installs and configures Geminabox"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.3.0"
+version          "0.3.1"
 
 depends 'unicorn'
 depends 'rc_mon'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "chrisroberts.code@gmail.com"
 license          "Apache 2.0"
 description      "Installs and configures Geminabox"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.2.0"
+version          "0.3.0"
 
 depends 'unicorn'
 depends 'rc_mon'

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -30,7 +30,7 @@ end
 if(node[:geminabox][:auth_required])
   if(node[:geminabox][:auth_required].is_a?(String))
     if(File.exists?(node[:geminabox][:auth_required]))
-      htpasswd_file = node[:geminabox][:auth_required]
+      geminabox_auth = node[:geminabox][:auth_required]
     else
       file File.join(node[:nginx][:dir], 'geminabox.htpasswd') do
         content node[:geminabox][:auth_required]
@@ -69,7 +69,8 @@ template File.join('/', 'etc', 'nginx', 'sites-available', 'geminabox') do
     :ssl => node[:geminabox][:ssl][:enabled],
     :ssl_cert => node[:geminabox][:ssl][:cert_file],
     :ssl_key => node[:geminabox][:ssl][:key_file],
-    :auth_file => geminabox_auth
+    :auth_file => geminabox_auth,
+    :limit_post => node[:geminabox][:limit_post]
   )
   mode '0644'
   notifies :restart, 'service[nginx]'

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -70,7 +70,8 @@ template File.join('/', 'etc', 'nginx', 'sites-available', 'geminabox') do
     :ssl_cert => node[:geminabox][:ssl][:cert_file],
     :ssl_key => node[:geminabox][:ssl][:key_file],
     :auth_file => geminabox_auth,
-    :limit_post => node[:geminabox][:limit_post]
+    :limit_post => node[:geminabox][:limit_post],
+    :network_list => node[:geminabox][:network_list]
   )
   mode '0644'
   notifies :restart, 'service[nginx]'

--- a/recipes/unicorn.rb
+++ b/recipes/unicorn.rb
@@ -17,6 +17,7 @@ unicorn_config File.join(node[:geminabox][:config_directory], 'geminabox.unicorn
   worker_processes node[:geminabox][:unicorn][:workers] || 2
   worker_timeout node[:geminabox][:unicorn][:timeout] || 30
   working_directory node[:geminabox][:base_directory]
+  pid ::File.join(node[:geminabox][:base_directory], 'unicorn.pid')
   preload_app true
   owner node[:geminabox][:www_user] || 'www-data'
   group node[:geminabox][:www_user] || 'www-data'

--- a/templates/default/nginx-geminabox.erb
+++ b/templates/default/nginx-geminabox.erb
@@ -11,10 +11,16 @@ server {
   proxy_set_header Host $http_host;
   location / {
     proxy_pass http://unicorn;
+    <% if @limit_post and @auth_file %>
+    limit_except GET HEAD {
+      auth_basic "Restricted access";
+      auth_basic_user_file <%= @auth_file %>;
+    }
+    <% end %>
   }
   <% end %>
   root <%= @root %>;
-  <% if @auth_file %>
+  <% if @auth_file and not @limit_post %>
   auth_basic "Restricted Access";
   auth_basic_user_file <%= @auth_file %>;
   <% end %>
@@ -31,12 +37,18 @@ server {
   ssl_ciphers HIGH;
   ssl_protocols SSLv3 TLSv1;
   ssl_prefer_server_ciphers on;
-  <% if @auth_file %>
+  <% if @auth_file and not @limit_post %>
   auth_basic "Restricted Access";
   auth_basic_user_file <%= @auth_file %>;
   <% end %>
   client_max_body_size <%= node[:geminabox][:nginx][:client_max_body_size] %>;
   location / {
+    <% if @limit_post and @auth_file %>
+    limit_except GET HEAD {
+      auth_basic "Restricted access";
+      auth_basic_user_file <%= @auth_file %>;
+    }
+    <% end %>
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Proto https;
     proxy_pass http://unicorn;

--- a/templates/default/nginx-geminabox.erb
+++ b/templates/default/nginx-geminabox.erb
@@ -16,6 +16,11 @@ server {
       auth_basic "Restricted access";
       auth_basic_user_file <%= @auth_file %>;
     }
+    <% elsif @limit_post and @network_list %>
+    limit_except GET HEAD {
+      allow <%= @network_list %>;
+      deny all;
+    }
     <% end %>
   }
   <% end %>
@@ -47,6 +52,11 @@ server {
     limit_except GET HEAD {
       auth_basic "Restricted access";
       auth_basic_user_file <%= @auth_file %>;
+    }
+    <% elsif @limit_post and @network_list %>
+    limit_except GET HEAD {
+      allow <%= @network_list %>;
+      deny all;
     }
     <% end %>
     proxy_set_header Host $http_host;


### PR DESCRIPTION
Options were to authenticate everything or nothing but I need to access
gems without authentication and use authentication to upload new gems or
delete existing ones.

This commit adds an additional option to authenticate just POST methods,
which allows users to download gems without authentication and prevents
unauthenticated users from uploading or deleting gems.

It also fixes an issue when auth_file exists, as auth_required value was being assigned to a variable that was never used.
